### PR TITLE
Widen contract spec type and event name limits

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -12,6 +12,12 @@ namespace stellar
 
 const SC_SPEC_DOC_LIMIT = 1024;
 
+// The limit on the name of a user-defined type, and on a reference to one. It
+// is longer than the limit on the names within a type, such as its fields or
+// cases, because a type's name qualifies it: it is the name of the module or
+// namespace the type is defined in, then the type's own name.
+const SC_SPEC_TYPE_NAME_LIMIT = 256;
+
 enum SCSpecType
 {
     SC_SPEC_TYPE_VAL = 0,
@@ -82,7 +88,7 @@ struct SCSpecTypeBytesN
 
 struct SCSpecTypeUDT
 {
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
 };
 
 union SCSpecTypeDef switch (SCSpecType type)
@@ -134,7 +140,7 @@ struct SCSpecUDTStructV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTStructFieldV0 fields<>;
 };
 
@@ -169,7 +175,7 @@ struct SCSpecUDTUnionV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTUnionCaseV0 cases<>;
 };
 
@@ -184,7 +190,7 @@ struct SCSpecUDTEnumV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTEnumCaseV0 cases<>;
 };
 
@@ -199,7 +205,7 @@ struct SCSpecUDTErrorEnumV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    string name<60>;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSpecUDTErrorEnumCaseV0 cases<>;
 };
 

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -249,7 +249,7 @@ struct SCSpecEventV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
-    SCSymbol name;
+    string name<SC_SPEC_TYPE_NAME_LIMIT>;
     SCSymbol prefixTopics<2>;
     SCSpecEventParamV0 params<>;
     SCSpecEventDataFormat dataFormat;

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -12,11 +12,7 @@ namespace stellar
 
 const SC_SPEC_DOC_LIMIT = 1024;
 
-// The limit on the name of a user-defined type, and on a reference to one. It
-// is longer than the limit on the names within a type, such as its fields or
-// cases, because a type's name qualifies it: it is the name of the module or
-// namespace the type is defined in, then the type's own name.
-const SC_SPEC_TYPE_NAME_LIMIT = 256;
+const SC_SPEC_TYPE_NAME_LIMIT = 1024;
 
 enum SCSpecType
 {


### PR DESCRIPTION
> [!NOTE]
> Part of a stack of PRs that must merge in this order.
>
> A first group of PRs change contract specs so that they are produced at compile time instead of at proc-macro execution time. This provides the foundation to construct the specs from information that is only known at compile time, like the fully qualified name of a type:
> 1. stellar/rs-stellar-xdr#580
> 1. stellar/rs-soroban-sdk#2061
> 1. stellar/rs-soroban-sdk#1965
>
> A second group of PRs changes the type names that the sdk stores in specs are fully qualified type names, and then the cli reduces them down to unique simple identifiers. During the contract build the types are given names like `::mycrate::mymod::MyType` instead of `MyType`. Then the cli reduces them back down to simple names after spec shaking. Qualified type names make it possible to uniquely identify types in the spec, even when they have the same name. This resolves several problems with contract specs the type identify problem (https://github.com/stellar/rs-soroban-sdk/issues/1570), type aliases limitations (https://github.com/stellar/rs-soroban-sdk/issues/1857 https://github.com/stellar/rs-soroban-sdk/issues/1063), and optimise spec shaking data section size (https://github.com/stellar/rs-soroban-sdk/issues/1978):
> 1. stellar/stellar-xdr#312 ← this PR
> 1. stellar/rs-stellar-xdr#543
> 1. stellar/rs-soroban-sdk#1970
> 1. stellar/stellar-cli#2674
>
> Note that downstream clients and SDKs should see no, or little, change because the cli will during the build process reduce the fully qualified names back to simple unique names. Contracts that had colliding type names, which meant they could not be used with clients, will now work.
>
> A third group of PRs are an optimisation to spec shaking v2, and will use the new unique type names to shake type specs by reachability, producing a dependency graph (thanks @mootz12), so that only spec entries that can't be reached from fns, like errors and events, get spec markers from dead-code-elimination:
> 1. stellar/rs-soroban-sdk#2043
> 1. stellar/stellar-cli#2720

### What

Add `SC_SPEC_TYPE_NAME_LIMIT` of 1024 and use it for the name of `SCSpecTypeUDT` and of the four user-defined type definition entries, in place of the 60 they had. The limits on names within a type, its fields and its cases, are unchanged.

### Why

A user-defined type's name is becoming a qualified name: the module or namespace it is defined in, then its own name. 60 characters does not hold one. Three types in the Rust SDK's own `auth` module already exceed it, the longest at 61 characters, so the limit binds immediately rather than in some unusual case.