### PR TITLE
Exclude SCV_EXECUTABLE_TAG from the spec check

### DIFF
--- a/.scripts/check-scspectype-superset.ts
+++ b/.scripts/check-scspectype-superset.ts
@@ -4,12 +4,17 @@
 
 import { readFileSync } from "node:fs";
 
-// SCValType variants that cannot cross a contract function boundary, and so
-// intentionally have no SCSpecType counterpart.
+// SCValType variants that intentionally have no SCSpecType counterpart.
 const EXCLUDED = [
+  // Internal values that cannot cross a contract function boundary.
   "CONTRACT_INSTANCE",
   "LEDGER_KEY_CONTRACT_INSTANCE",
   "LEDGER_KEY_NONCE",
+  // Technically can be passed across a contract function boundary, but the SDK
+  // does not support it and does not plan to. For a better and more consistent
+  // UX the SDK exposes the executable tag everywhere as a String, and uses
+  // SCV_EXECUTABLE_TAG as a storage implementation detail.
+  "EXECUTABLE_TAG",
 ];
 
 const spec = readFileSync("Stellar-contract-spec.x", "utf8");


### PR DESCRIPTION
### What

Add `EXECUTABLE_TAG` to the excluded variants in `.scripts/check-scspectype-superset.ts`, with a comment recording why it is excluded despite being passable across a contract function boundary.

### Why

The check has failed on `main` since it merged in #314, because `SCV_EXECUTABLE_TAG` from CAP-85 has no `SC_SPEC_TYPE_EXECUTABLE_TAG` — the SDK deliberately exposes the executable tag everywhere as a String for a better and more consistent UX, treating `SCV_EXECUTABLE_TAG` as a storage implementation detail, so no spec type is planned.
