### PR TITLE
Add gated StellarValue arms for millisecond close times

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -15,6 +15,11 @@ enum StellarValueType
     STELLAR_VALUE_BASIC = 0,
     STELLAR_VALUE_SIGNED = 1,
     STELLAR_VALUE_EMPTY_TX_SET = 2
+#ifdef MS_CLOSE_TIME
+    ,
+    STELLAR_VALUE_SIGNED_MS = 3,
+    STELLAR_VALUE_EMPTY_TX_SET_MS = 4
+#endif // MS_CLOSE_TIME
 };
 
 struct LedgerCloseValueSignature
@@ -52,6 +57,23 @@ struct StellarValue
             uint32 previousLedgerVersion;
             LedgerCloseValueSignature lcValueSignature;
         } proposedValue;
+#ifdef MS_CLOSE_TIME
+    case STELLAR_VALUE_SIGNED_MS:
+        struct
+        {
+            uint32 closeTimeMs; // millisecond component of closeTime, [0, 999]
+            LedgerCloseValueSignature lcValueSignature;
+        } signedMsValue;
+    case STELLAR_VALUE_EMPTY_TX_SET_MS:
+        struct
+        {
+            uint32 closeTimeMs; // millisecond component of closeTime, [0, 999]
+            Hash txSetHash;
+            Hash previousLedgerHash;
+            uint32 previousLedgerVersion;
+            LedgerCloseValueSignature lcValueSignature;
+        } proposedMsValue;
+#endif // MS_CLOSE_TIME
     }
     ext;
 };


### PR DESCRIPTION
Adds millisecond resolution closeTime. The goal here was to be the least disruptive as possible. We could just re-interpret the closeTime value as ms on a protocol upgrade, but it would be a pain for downstream systems, and every block-explorer and indexer with full history would need to support the change moving forward.

Instead, I've just added an additional field that will represent the ms component of close time. If downstream systems ignore this change (assuming they still pick up the new XDR library), it's fine, as they just don't reason in ms, but the whole second component remains unchanged. 

Adds two new `StellarValue` ext arms, gated behind `MS_CLOSE_TIME`:

- `STELLAR_VALUE_SIGNED_MS = 3` — `{ uint32 closeTimeMs; LedgerCloseValueSignature lcValueSignature; }`
- `STELLAR_VALUE_EMPTY_TX_SET_MS = 4` — the empty-tx-set shape (CAP-0083) plus `closeTimeMs`

`closeTimeMs` carries the millisecond component of the ledger close time, range [0, 999]; the existing whole-second `closeTime` field keeps its semantics for all existing consumers.