### PR TITLE
Make closeTimeMs the full close time in milliseconds

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -61,13 +61,13 @@ struct StellarValue
     case STELLAR_VALUE_SIGNED_MS:
         struct
         {
-            uint32 closeTimeMs; // millisecond component of closeTime, [0, 999]
+            TimePointMilliseconds closeTimeMs; // closeTime == closeTimeMs / 1000
             LedgerCloseValueSignature lcValueSignature;
         } signedMsValue;
     case STELLAR_VALUE_EMPTY_TX_SET_MS:
         struct
         {
-            uint32 closeTimeMs; // millisecond component of closeTime, [0, 999]
+            TimePointMilliseconds closeTimeMs; // closeTime == closeTimeMs / 1000
             Hash txSetHash;
             Hash previousLedgerHash;
             uint32 previousLedgerVersion;

--- a/Stellar-types.x
+++ b/Stellar-types.x
@@ -16,6 +16,10 @@ typedef hyper int64;
 
 typedef uint64 TimePoint;
 typedef uint64 Duration;
+#ifdef MS_CLOSE_TIME
+// Milliseconds since the Unix epoch. TimePoint is whole seconds.
+typedef uint64 TimePointMilliseconds;
+#endif // MS_CLOSE_TIME
 
 // An ExtensionPoint is always marshaled as a 32-bit 0 value.  At a
 // later point, it can be replaced by a different union so as to


### PR DESCRIPTION
Follow-up to #316, tracking the update to CAP-0088 in stellar/stellar-protocol#1999.

`closeTimeMs` now carries the **full** close time in milliseconds since the Unix epoch, rather than only the sub-second component in `[0, 999]`. `closeTime` is unchanged: it remains the whole-second value that every non-consensus protocol feature (time bounds, sequence age, claim predicates, Soroban timestamps, upgrade scheduling) keeps reading, and the two fields must agree:

```
closeTime == closeTimeMs / 1000
```

Changes:
- `Stellar-types.x`: new `TimePointMilliseconds` typedef (`uint64`, milliseconds since epoch), mirroring `TimePoint` (whole seconds). Gated behind `MS_CLOSE_TIME` like the arms that use it, so it appears in the generated `next` branch only and `curr` is untouched.
- `Stellar-ledger.x`: both `STELLAR_VALUE_SIGNED_MS` and `STELLAR_VALUE_EMPTY_TX_SET_MS` carry `TimePointMilliseconds closeTimeMs` instead of `uint32 closeTimeMs`.

Rationale, as in the CAP: a self-contained ms timestamp lets downstream consumers use `closeTimeMs` directly without recombining two fields, while `closeTime` stays redundant for anything that only reasons in whole seconds. The redundancy is validated by core (a value whose `closeTime != closeTimeMs / 1000` is rejected).

Core-side implementation: stellar/stellar-core#5423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
